### PR TITLE
Adding in switch_lang

### DIFF
--- a/facetwp-wpml.php
+++ b/facetwp-wpml.php
@@ -59,6 +59,8 @@ class FWP_WPML
 
     // Index all languages
     function indexer_query_args( $args ) {
+        global $sitepress;
+        $sitepress->switch_lang('all');
         $args['suppress_filters'] = true; // query posts in all languages
         return $args;
     }


### PR DESCRIPTION
Adding in switch_lang since suppress_filters wasn't working with the current versions of WPML and FacetWP. It still limited the selection by language.